### PR TITLE
Minor Repository Housekeeping

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Marc Boudreau
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This section describes the prerequisites needed to be able to run Terraform with
 
 ### Terraform Cloud Workspace
 
-1. Create a workspace in [Terraform Cloud](https://app.terraform.io/) named `accentis-gcp-project-` and the numerical suffix that follows `accentis-` in the GCP project ID.  For example, for GCP project `accentis-288921`, the workspace name is `accentis-gcp-project-288921`.
+1. Create a workspace in [Terraform Cloud](https://app.terraform.io/) named `accentis-gcp-project-` and the numerical suffix that follows `accentis-` in the GCP project ID.  For example, for GCP project `accentis-111222`, the workspace name is `accentis-gcp-project-111222`.
 1. In the created Terraform Cloud workspace, set a **Variable** named **project_id** and set its value to the GCP Project ID.
 
 ### GCP Service Account

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,14 @@
+################################################################################
+#
+# accentis-gcp-project
+#   A Terraform project that configures a Google Cloud Platform Project in order
+#   to run Accentis deployments.
+#
+# main.tf
+#   Defines the Terraform settings and resources for the project.
+#
+################################################################################
+
 terraform {
   required_version = "~> 0.14"
 
@@ -128,7 +139,7 @@ resource "google_project_iam_binding" "gke_cluster_module" {
 }
 
 resource "google_service_account_iam_binding" "default_compute_engine" {
-  service_account_id = "projects/accentis-288921/serviceAccounts/521113983161-compute@developer.gserviceaccount.com"
+  service_account_id = "projects/${var.project_id}/serviceAccounts/${var.default_compute_engine_service_account}"
   role               = "roles/iam.serviceAccountUser"
 
   members = [

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,20 @@
+################################################################################
+#
+# accentis-gcp-project
+#   A Terraform project that configures a Google Cloud Platform Project in order
+#   to run Accentis deployments.
+#
+# variables.tf
+#   Defines the input variables for the project.
+#
+################################################################################
+
 variable "project_id" {
     description = "The GCP project ID"
+    type        = string
+}
+
+variable "default_compute_engine_service_account" {
+    description = "The email address of the Compute Engine default service account."
     type        = string
 }


### PR DESCRIPTION
This change introduces:
* the MIT license for the repository
* removed mention of specific GCP project from README and used a made-up project ID for the example
* replaced hardcoded email for Compute Engine default service account and added a variable instead